### PR TITLE
CIDRs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,22 @@ const app = new Koa();
 //app.proxy = true
 
 // Use middleware instead
-// 1st parameter is array or comma-separated list of trusted proxies, default ['127.0.0.1', '::1']
+// 1st parameter is array or comma-separated list of trusted proxies, default ['127.0.0.1/8', '::1/128']
 // 2nd parameter is trusted header, default is X-Forwarded-For
 app.use(trustProxy('127.0.0.1, ::1', 'X-Real-IP'));
+// You can use CIDRs as well
+app.use(trustProxy('192.168.0.1/24, ::1/128', 'X-Real-IP'));
 
 ..........
 ```
+
+## Aliases
+
+This module also supports well-known aliases:
+
+* loopback: 127.0.0.1/8, ::1/128,
+* linklocal: 169.254.0.0/16, fe80::/10
+* uniquelocal: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "mocha": "^6.1.4",
     "nyc": "^14.1.0",
     "supertest": "^4.0.2"
+  },
+  "dependencies": {
+    "ip6addr": "^0.2.3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -50,6 +50,30 @@ describe('trustProxy with proxylist "7.7.7.7, 8.8.8.8"', function () {
 	});
 });
 
+describe('trustProxy with proxylist "7.7.7.7/8, 8.8.8.8/8"', function () {
+	const app = new Koa()
+	app.use(trustProxy('7.7.7.7, 8.8.8.8'));
+	app.use(async (ctx) => ctx.body = ctx.request.ip );
+	const server = app.listen();
+	it('x-forwarded-for should be completely ignored', function (done) {
+        request(server).get('/')
+			.set('X-Forwarded-For', '5.5.5.5, 6.6.6.6')
+			.expect(LOCAL_IP, done);
+	});
+});
+
+describe('trustProxy with proxylist "1.2.3.4, 127.0.0.1, 5.6.7.8"', function () {
+	const app = new Koa()
+	app.use(trustProxy('1.2.3.4, 127.0.0.1, 5.6.7.8'));
+	app.use(async (ctx) => ctx.body = ctx.request.ip );
+	const server = app.listen();
+	it('should return rightmost untrusted proxy', function (done) {
+        request(server).get('/')
+			.set('X-Forwarded-For', '6.5.4.3, 1.2.3.5, 5.6.7.8')
+			.expect('1.2.3.5', done);
+	});
+});
+
 describe('trustProxy with proxylist "1.2.3.4, 127.0.0.1, 5.6.7.8"', function () {
 	const app = new Koa()
 	app.use(trustProxy('1.2.3.4, 127.0.0.1, 5.6.7.8'));


### PR DESCRIPTION
Currently the module supports only fixed IPs and does not work with networks (for example 192.168.0.0/24). This PR adds support for any CIDR (both v4 and v6)
